### PR TITLE
[LOAN-36] Fixing out of bounds number error for Dai spend approval.

### DIFF
--- a/src/models/Contracts.tsx
+++ b/src/models/Contracts.tsx
@@ -34,7 +34,7 @@ export async function approveDai(lendingPool: any, web3State: any, primaryAddres
   return new Promise((resolve, reject) => dai.methods
     .approve(
       lendingPool._address,
-      (Math.pow(2, 256)-1).toLocaleString('fullwide', { useGrouping:false })
+      (amount*tokenDecimals).toLocaleString('fullwide', { useGrouping:false })
     )
     .send({ from: primaryAddress })
     .on('transactionHash', Notify.hash)


### PR DESCRIPTION
# Description

Metamask errors when a user tries to approve Dai in the lending section. It currently requests the maximum amount possible and errors. I believe this is a new situation with the Metamask update, so for now I'm adding a request for the exact amount that will be spent in the loan.

# Testing

1. Connect Metamask to Ropsten.
2. Get ETH from the Ropsten faucet.
3. Get Dai from the app.compound faucet.
4. Open the Teller app and go to Lending.
5. Click the Submit button in the Approve section. You should see a popout requesting approval for Dai spend for the exact amount in the Loan amount form.

# Screenshots

![Screenshot from 2020-08-10 22-29-26](https://user-images.githubusercontent.com/1673206/89850838-12ab2600-db59-11ea-8604-401726632777.png)
![Screenshot from 2020-08-10 22-29-30](https://user-images.githubusercontent.com/1673206/89850843-150d8000-db59-11ea-84d9-881f5386f5c8.png)
![Screenshot from 2020-08-10 22-29-36](https://user-images.githubusercontent.com/1673206/89850847-16d74380-db59-11ea-8492-3282d1d5696b.png)


# Issue

https://teller-finance.atlassian.net/browse/LOAN-36